### PR TITLE
Added SHA and Unix timestamp to container tag

### DIFF
--- a/.github/workflows/image-deploy.yaml
+++ b/.github/workflows/image-deploy.yaml
@@ -37,10 +37,14 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +%s)"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ github.sha }}-${{ steps.date.outputs.date }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- Added SHA hash to container tag.
- Added Unix timestamp to container tag.

Just a word of warning, this will generate a lot of images on your profile. Once you merge this, it's a good idea to only work inside of a feature branch, and merge into `main` when you are ready to go live.

This is also part I of these fixes. Part II will require editing the local cluster files so that flux will watch the container repository for changes.